### PR TITLE
Mark/template

### DIFF
--- a/Handler.py
+++ b/Handler.py
@@ -36,8 +36,8 @@ def test_annuity_template():
     assert round(annuity.output_df.expected_reserves.values[0]) == 390890
 def test_investment_template():
     config.set_investment()
-    investment = template_maker.make_template(template_class = Main.MultipleTemplate)
-    assert round(investment.output_df.expected_reserves.values[20]) == 64760
+    investment = template_maker.make_template(template_class = Main.InvestmentTemplate)
+    assert round(investment.output_df.expected_reserves.values[0]) == 17544
 def test_multiple_template():
     config.set_multiple()
     multiple = template_maker.make_template(template_class = Main.MultipleTemplate)

--- a/Handler.py
+++ b/Handler.py
@@ -34,6 +34,10 @@ def test_annuity_template():
     config.annuity_start_age = 60
     annuity = template_maker.make_template(template_class = Main.AnnuityTemplate)
     assert round(annuity.output_df.expected_reserves.values[0]) == 390890
+def test_investment_template():
+    config.set_investment()
+    investment = template_maker.make_template(template_class = Main.MultipleTemplate)
+    assert round(investment.output_df.expected_reserves.values[20]) == 64760
 def test_multiple_template():
     config.set_multiple()
     multiple = template_maker.make_template(template_class = Main.MultipleTemplate)
@@ -77,6 +81,7 @@ def test_multiple():
 def test_all():
     test_annuity_yield()
     test_insurance_template()
+    test_investment_template()
     test_annuity_template()
     test_multiple_template()
     test_random_saved()

--- a/Main.py
+++ b/Main.py
@@ -194,7 +194,7 @@ class MultipleDeduct(Multiple, InsuranceDeduct):
         self.deduct_threshold = 1.2
 
 # Template
-class _Template(Insurance):
+class _Template:
     def __init__(self, config):
         super().__init__(config)
         self.round = False
@@ -214,7 +214,7 @@ class _Template(Insurance):
         '''
         self.discount = (1+self.config.mean_interest) ** -self.output_df.index
         self.output_df['expected_reserves'] = self.output_df.index.map(self._calculate_expected_reserves_one_year) / self.discount / self.output_df.policies
-class InsuranceTemplate(_Template):
+class InsuranceTemplate(Insurance, _Template):
     def __init__(self, config):
         super().__init__(config)
         self.round = True

--- a/Main.py
+++ b/Main.py
@@ -201,6 +201,7 @@ class _Template(Insurance):
         start_policies = float('nan') if start_policies == 0 else start_policies
         # Ensures that discount starts from 1, even at year n > 1
         self.multiplier = (1+self.config.mean_interest) ** year / start_policies
+        # This function is finished differently by every child class
     def calculate_expected_reserves(self):
         # Discount doesn't depend on start year, so only needs to be calculated once
         self.discount = self.output_df.index.map(lambda x: (1+self.config.mean_interest) ** -x)
@@ -220,8 +221,10 @@ class AnnuityTemplate(Annuity, _Template):
     def _calculate_expected_reserves_one_year(self, year: int) -> float:
         super()._calculate_expected_reserves_one_year(year)
         # Claims are based on number alive
+        # discount all claims to year 0
         future_claims = (self.output_df.claims[year+1:] * self.discount[year+1:]).sum()
         # Premium is excluded because annuities don't have premiums after year 0
+        # undiscount future_claims from year 0 to current year 
         expected_reserves = future_claims * self.multiplier
         return expected_reserves
 class AnnuityIncrementTemplate(AnnuityTemplate, AnnuityIncrement):

--- a/Main.py
+++ b/Main.py
@@ -205,6 +205,7 @@ class MultipleDeduct(Multiple, InsuranceDeduct):
 '''
 class _Template:
     def __init__(self, config):
+        super().__init__(config)
         self.round = False
     def _calculate_expected_reserves_one_year(self, year: int) -> float:
         future_premiums = (self.output_df.premiums[year+1:] * self.discount[year+1:]).sum()

--- a/Main.py
+++ b/Main.py
@@ -214,15 +214,10 @@ class InsuranceTemplate(_Template):
         future_claims = (self.output_df.claims[year+1:] * self.discount[year+1:]).sum()
         expected_reserves = future_claims - future_premiums
         return expected_reserves
-class AnnuityTemplate(Annuity, _Template):
+class AnnuityTemplate(Annuity, InsuranceTemplate):
     def __init__(self, config):
         super().__init__(config)
         self.round = False
-    def _calculate_expected_reserves_one_year(self, year: int) -> float:
-        # Claims are based on number alive
-        future_claims = (self.output_df.claims[year+1:] * self.discount[year+1:]).sum()
-        # Premium is excluded because annuities don't have premiums after year 0
-        return future_claims
 class AnnuityIncrementTemplate(AnnuityTemplate, AnnuityIncrement):
     pass
 class InvestmentTemplate(Investment, _Template): # Not being used
@@ -231,7 +226,7 @@ class InvestmentTemplate(Investment, _Template): # Not being used
         self.round = False
     def _calculate_expected_reserves_one_year(self, year: int) -> float:
         # Bug Fix: Same As Multiple Template
-        future_claims = self.output_df.claims[self.years] * self.discount[self.years] if year < self.years else 0
+        future_claims = (self.output_df.claims[year+1:] * self.discount[year+1:]).sum()
         future_premiums = (self.output_df.premiums[year+1:self.years] * self.discount[year+1:self.years]).sum()
         expected_reserves = future_claims - future_premiums
         return expected_reserves

--- a/Main.py
+++ b/Main.py
@@ -226,7 +226,7 @@ class _Template:
         self.output_df['expected_reserves'] = self.output_df.index.map(self._calculate_expected_reserves_one_year) / self.discount / self.output_df.policies
 class InsuranceTemplate(Insurance, _Template):
     pass
-class EndowmentTemplate(_Template, Endowment):
+class EndowmentTemplate(Endowment, _Template):
     pass
 class AnnuityTemplate(_Template, Annuity):
     pass

--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@
     - Main.process_df
 - monte_carlo
     - _set_simulation_variables
-        - Handler.make_template
+        - Template.make_template
     - _run_simulations
         - Main.calculate_actual_reserves
         - _calculate_positive

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import Main, Config, Tester, Handler"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -36,6 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import Main, Config\n",
+    "\n",
     "config = Config.Config(simulate=False)\n",
     "config.set_dfs(random_condition = 'random_dynamic')\n",
     "# Change config.set_insurance, Main.Insurance to try other types of insurance products\n",
@@ -60,6 +53,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import Main, Config, Tester\n",
+    "\n",
     "config = Config.Config(simulate=True)\n",
     "config.set_dfs(random_condition = 'random_dynamic')\n",
     "# Change config.set_insurance, Main.InsuranceTemplate, Main.Insurance to try other types of insurance products\n",
@@ -83,6 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import Handler\n",
+    "\n",
     "Handler.test_all()"
    ]
   },


### PR DESCRIPTION
- Subclasses must inherit _Template first, 
    - So that init uses self.round = False (from _Template) instead of self.round = True (from other classes)
    - Except InsuranceTemplate, which uses self.round = True
    - This is following the class's logic
- Originally I had custom logic for each subclass (see commit 0e2aeaf)
    - It was duplicating the insurance type's logic using self.policies and self.deaths
    - So I replaced everything with premiums and claims, to reuse logic